### PR TITLE
Created Python article on how to use the argparse module (1 min)

### DIFF
--- a/python/026-using-argparse.md
+++ b/python/026-using-argparse.md
@@ -70,11 +70,3 @@ print('The area of your rectangle is: ', area, ' units squared.')
 Thats about it! Argparse will now parse your command-line agruments for integers to be used in our method. Every parser will have a `-h` optional argument by default; this option will display the help message along with the parser's description.
 
 <img src="https://cdn.discordapp.com/attachments/500822770092081163/772226353188831272/026.PNG" alt="Using -h to display help message" width="550">
-
-
-
-
-
-
-
-

--- a/python/026-using-argparse.md
+++ b/python/026-using-argparse.md
@@ -1,18 +1,21 @@
 ---
 id: 026-using-argparse
-title: Creating a Command-Line Interface Program
-tags: Python, cli, args
+title: Creating a Command-Line Interface Program With Argparse
+tags: Python, cli, args, argparse
 author: Royce Ayroso-Ong
-meta-description: Using argparse to create a simple command line interface program
+meta-description: Using argparse to create a simple command-line interface program
 ---
 
 # What is Argparse?
 
-Argparse is a Python package that comes pre-installed when you install Python. It is a module that allows for the creation of user-friendly command-line interfaces.
+[Argparse](https://docs.python.org/3/library/argparse.html) is a module that comes pre-installed when you install Python. It allows for the creation of user-friendly command-line interfaces.
 
 ## Creating a CLI Program to Find the Area of a Rectangle
 
-To start using argparse, you will need to import the pacakge:
+<img src="https://cdn.discordapp.com/attachments/500822770092081163/772226648116035604/026b.PNG" alt="Using argparse to parse two integers" width="550">
+
+
+To start using argparse to recreate the example above, you will need to import the pacakge:
 
 ```python
 # the following code will be contained within a file called area.py
@@ -28,10 +31,10 @@ def area_of_rectangle(length, width):
 
 This method will be called when the program is executed. The parameters `length` and `width` will be extracted from the command line arguments.  
 
-Then we must create a parser to handle the parsing of command-line arguments along with two positional arguments that we want to extract, i.e. the length and the width of the rectangle.
+Now we must create a parser to handle the parsing of command-line arguments along with two positional arguments that we want to extract, i.e. the length and the width of the rectangle.
 
 ```python
-parser = argparse.ArgumentParser(description='Adds two number arguments together and prints the sum.')
+parser = argparse.ArgumentParser(description='Calculates the area of a rectangle')
 
 parser.add_argument('length', default=0, type=int, help='An integer for the length of the rectangle')
 parser.add_argument('width', default=0, type=int, help='An integer for the width of the rectangle')
@@ -66,10 +69,12 @@ print('The area of your rectangle is: ', area, ' units squared.')
 
 Thats about it! Argparse will now parse your command-line agruments for integers to be used in our method. Every parser will have a `-h` optional argument by default; this option will display the help message along with the parser's description.
 
-**To see our program in action, see example below:**
+<img src="https://cdn.discordapp.com/attachments/500822770092081163/772226353188831272/026.PNG" alt="Using -h to display help message" width="550">
 
-![Using -h to display help message](https://cdn.discordapp.com/attachments/500822770092081163/772226353188831272/026.PNG | width=100)
-![Using argparse to parse two integers](https://cdn.discordapp.com/attachments/500822770092081163/772226648116035604/026b.PNG)
+
+
+
+
 
 
 

--- a/python/026-using-argparse.md
+++ b/python/026-using-argparse.md
@@ -1,0 +1,75 @@
+---
+id: 026-using-argparse
+title: Creating a Command-Line Interface Program
+tags: Python, cli, args
+author: Royce Ayroso-Ong
+meta-description: Using argparse to create a simple command line interface program
+---
+
+# What is Argparse?
+
+Argparse is a Python package that comes pre-installed when you install Python. It is a module that allows for the creation of user-friendly command-line interfaces.
+
+## Creating a CLI Program to Find the Area of a Rectangle
+
+To start using argparse, you will need to import the pacakge:
+
+```python
+# the following code will be contained within a file called area.py
+import argparse
+```
+
+Now we will create a simple method to multiply and return two numbers, like so:
+
+```python
+def area_of_rectangle(length, width):
+    return length * width
+```
+
+This method will be called when the program is executed. The parameters `length` and `width` will be extracted from the command line arguments.  
+
+Then we must create a parser to handle the parsing of command-line arguments along with two positional arguments that we want to extract, i.e. the length and the width of the rectangle.
+
+```python
+parser = argparse.ArgumentParser(description='Adds two number arguments together and prints the sum.')
+
+parser.add_argument('length', default=0, type=int, help='An integer for the length of the rectangle')
+parser.add_argument('width', default=0, type=int, help='An integer for the width of the rectangle')
+```
+
+We can use the values of these arguments by calling upon `parser.parse_args()`.
+
+```python
+args = parser.parse_args()
+area = area_of_rectangle(args.length, args.width)
+print('The area of your rectangle is: ', area, ' units squared.')
+```
+
+Putting everything together should look like this:
+
+```Python
+# area.py
+import argparse
+
+def area_of_rectangle(length, width):
+    return length * width
+
+parser = argparse.ArgumentParser(description='Calculates the area of a rectangle')
+
+parser.add_argument('length', default=0, type=int, help='An integer for the length of the rectangle')
+parser.add_argument('width', default=0, type=int, help='An integer for the width of the rectangle')
+
+args = parser.parse_args()
+area = area_of_rectangle(args.length, args.width)
+print('The area of your rectangle is: ', area, ' units squared.')
+```
+
+Thats about it! Argparse will now parse your command-line agruments for integers to be used in our method. Every parser will have a `-h` optional argument by default; this option will display the help message along with the parser's description.
+
+**To see our program in action, see example below:**
+
+![Using -h to display help message](https://cdn.discordapp.com/attachments/500822770092081163/772226353188831272/026.PNG | width=100)
+![Using argparse to parse two integers](https://cdn.discordapp.com/attachments/500822770092081163/772226648116035604/026b.PNG)
+
+
+


### PR DESCRIPTION
In response to the issue #87 I went ahead and created a short article on using Python's command-line argument parser, [argparse](https://docs.python.org/3/library/argparse.html).

In short, the article is a concise tutorial on the basics of using argparse to create a program that calculates the area of a rectangle with the user's input (which is extracted from the command prompt).

Here are examples of what I am referring to:

<img src="https://cdn.discordapp.com/attachments/500822770092081163/772226353188831272/026.PNG" alt="Using -h to display help message" width="400">
<img src="https://cdn.discordapp.com/attachments/500822770092081163/772226648116035604/026b.PNG" alt="Using argparse to parse two integers" width="400">

If there are any changes that you want to be made, feel free to let me know. Thank you.
